### PR TITLE
refactor: Make annotate run one-at-a-time

### DIFF
--- a/modules/local/annotate/idmapping.nf
+++ b/modules/local/annotate/idmapping.nf
@@ -1,5 +1,6 @@
 process ANNOTATE {
     label 'process_medium'
+    maxForks 1
 
     conda "arthurvinx::medusaPipeline"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
- Multiple instances of annotate trying to access the same database
  leads to plyvel's 'locked resource' error.
- Find ways of refactoring this in the future to make it fully parallel
